### PR TITLE
Add simple Lichess integration

### DIFF
--- a/src/components/LichessGameViewModel.ts
+++ b/src/components/LichessGameViewModel.ts
@@ -1,0 +1,30 @@
+import { BaseViewModel } from "../core/BaseViewModel";
+import { observable } from "knockout";
+import { LichessApiService } from "../services/LichessApiService";
+
+export class LichessGameViewModel extends BaseViewModel {
+    public gameUrl = observable<string | null>(null);
+    private api: LichessApiService;
+
+    constructor(context: PageJS.Context | undefined) {
+        super(context);
+        this.api = new LichessApiService("YOUR_LICHESS_TOKEN");
+        this.setTemplate(`
+            <div>
+                <button data-bind="click: startGame">Start AI Game</button>
+                <div data-bind="if: gameUrl">
+                    <a data-bind="attr: { href: gameUrl }, text: gameUrl" target="_blank"></a>
+                </div>
+            </div>
+        `);
+    }
+
+    async startGame() {
+        try {
+            const response = await this.api.challengeAi();
+            this.gameUrl(response.challenge.url);
+        } catch (err) {
+            console.error(err);
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,14 @@ import page from "page";
 import {renderView} from "./core/BaseViewModel";
 import {AppViewModel} from "./components/AppViewModel";
 import {NotFoundViewModel} from "./components/NotFoundViewModel";
+import {LichessGameViewModel} from "./components/LichessGameViewModel";
 import {logPathMiddleware} from "./middlewares/middlewares";
 
 const BASE_PATH = "/";
 
 page("*", logPathMiddleware);
 page(BASE_PATH, (context) => renderView(AppViewModel, context));
+page("/lichess", (context) => renderView(LichessGameViewModel, context));
 page("*", () => renderView(NotFoundViewModel));
 
 page();

--- a/src/services/LichessApiService.ts
+++ b/src/services/LichessApiService.ts
@@ -1,0 +1,39 @@
+export interface AiChallengeOptions {
+    level?: number;
+    color?: 'white' | 'black' | 'random';
+}
+
+export interface AiChallengeResponse {
+    challenge: {
+        id: string;
+        url: string;
+    };
+}
+
+export class LichessApiService {
+    private token: string;
+
+    constructor(token: string) {
+        this.token = token;
+    }
+
+    async challengeAi(options: AiChallengeOptions = {}): Promise<AiChallengeResponse> {
+        const params = new URLSearchParams();
+        params.set('level', String(options.level ?? 1));
+        params.set('color', options.color ?? 'random');
+
+        const response = await fetch('https://lichess.org/api/challenge/ai', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${this.token}`,
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: params.toString()
+        });
+
+        if (!response.ok) {
+            throw new Error(`Lichess API error: ${response.statusText}`);
+        }
+        return response.json() as Promise<AiChallengeResponse>;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LichessApiService` to call the Lichess API
- add `LichessGameViewModel` with a button to start an AI game
- register new route in `index.ts`

## Testing
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_686308f3c358832688b818cee9dd1535