### PR TITLE
Implement Lichess OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ A TypeScript-powered web application starter with modern tools and frameworks. T
 1. Clone the repository.
 2. Install dependencies with `npm install`.
 3. Start your development server with `npm run serve:dev`.
+
+### Lichess OAuth Setup
+
+The AI challenge feature requires an OAuth token from Lichess. Create an OAuth
+application on Lichess and copy the **client ID** and **redirect URI** into
+`LichessGameViewModel.ts`. When visiting the Lichess page for the first time you
+will be redirected to Lichess to authorise the application. After authorisation,
+the token is stored in `localStorage` and used for subsequent AI challenges.

--- a/src/components/LichessGameViewModel.ts
+++ b/src/components/LichessGameViewModel.ts
@@ -1,25 +1,51 @@
 import { BaseViewModel } from "../core/BaseViewModel";
 import { observable } from "knockout";
 import { LichessApiService } from "../services/LichessApiService";
+import { LichessAuthService } from "../services/LichessAuthService";
 
 export class LichessGameViewModel extends BaseViewModel {
     public gameUrl = observable<string | null>(null);
-    private api: LichessApiService;
+    public isAuthenticated = observable<boolean>(false);
+    private api: LichessApiService | null = null;
+    private auth: LichessAuthService;
 
     constructor(context: PageJS.Context | undefined) {
         super(context);
-        this.api = new LichessApiService("YOUR_LICHESS_TOKEN");
+        this.auth = new LichessAuthService("YOUR_CLIENT_ID", window.location.origin + "/lichess");
+        const token = this.auth.getAccessToken();
+        if (token) {
+            this.api = new LichessApiService(token);
+            this.isAuthenticated(true);
+        }
         this.setTemplate(`
             <div>
+                <!-- ko if: isAuthenticated -->
                 <button data-bind="click: startGame">Start AI Game</button>
                 <div data-bind="if: gameUrl">
                     <a data-bind="attr: { href: gameUrl }, text: gameUrl" target="_blank"></a>
                 </div>
+                <!-- /ko -->
+                <!-- ko ifnot: isAuthenticated -->
+                <button data-bind="click: login">Login with Lichess</button>
+                <!-- /ko -->
             </div>
         `);
     }
 
+    login() {
+        this.auth.authenticate();
+    }
+
     async startGame() {
+        if (!this.api) {
+            const token = this.auth.getAccessToken();
+            if (!token) {
+                this.auth.authenticate();
+                return;
+            }
+            this.api = new LichessApiService(token);
+            this.isAuthenticated(true);
+        }
         try {
             const response = await this.api.challengeAi();
             this.gameUrl(response.challenge.url);

--- a/src/services/LichessAuthService.ts
+++ b/src/services/LichessAuthService.ts
@@ -1,0 +1,63 @@
+export class LichessAuthService {
+    private clientId: string;
+    private redirectUri: string;
+    private scope: string;
+    private storageKey = 'lichess_token';
+
+    constructor(clientId: string, redirectUri: string, scope: string = 'challenge:write') {
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+        this.scope = scope;
+    }
+
+    /**
+     * Initiates the OAuth flow by redirecting the user to Lichess.
+     */
+    authenticate(): void {
+        const url = new URL('https://lichess.org/oauth');
+        url.searchParams.set('response_type', 'token');
+        url.searchParams.set('client_id', this.clientId);
+        url.searchParams.set('redirect_uri', this.redirectUri);
+        url.searchParams.set('scope', this.scope);
+        window.location.href = url.toString();
+    }
+
+    /**
+     * Returns the stored access token if available.
+     */
+    getAccessToken(): string | null {
+        const tokenInStorage = localStorage.getItem(this.storageKey);
+        if (tokenInStorage) {
+            return tokenInStorage;
+        }
+        const tokenInUrl = this.extractTokenFromUrl();
+        if (tokenInUrl) {
+            this.saveToken(tokenInUrl);
+            this.clearUrlFragment();
+            return tokenInUrl;
+        }
+        return null;
+    }
+
+    logout(): void {
+        localStorage.removeItem(this.storageKey);
+    }
+
+    private saveToken(token: string): void {
+        localStorage.setItem(this.storageKey, token);
+    }
+
+    private extractTokenFromUrl(): string | null {
+        const hash = window.location.hash.substring(1);
+        const params = new URLSearchParams(hash);
+        const token = params.get('access_token');
+        return token;
+    }
+
+    private clearUrlFragment(): void {
+        if (window.history.replaceState) {
+            const url = window.location.origin + window.location.pathname;
+            window.history.replaceState(null, '', url);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add simple OAuth2 helper for Lichess
- wire authentication into the AI game view
- document OAuth setup

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'knockout' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68630b86c4508326bd8e3717f55afd88