### PR TITLE
Fix AI challenge response handling

### DIFF
--- a/src/components/LichessGameViewModel.ts
+++ b/src/components/LichessGameViewModel.ts
@@ -52,7 +52,11 @@ export class LichessGameViewModel extends BaseViewModel {
         }
         try {
             const response = await this.api.challengeAi();
-            this.gameUrl(response.challenge.url);
+            if (response.challenge && response.challenge.url) {
+                this.gameUrl(response.challenge.url);
+            } else {
+                console.error("Unexpected response from Lichess", response);
+            }
         } catch (err) {
             console.error(err);
         }


### PR DESCRIPTION
## Summary
- handle missing `challenge.url` in `LichessGameViewModel`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_686442145ee48326963740455c3a866d