### PR TITLE
Enable embedded Lichess AI games

### DIFF
--- a/src/components/LichessGameViewModel.ts
+++ b/src/components/LichessGameViewModel.ts
@@ -5,6 +5,7 @@ import { LichessAuthService } from "../services/LichessAuthService";
 
 export class LichessGameViewModel extends BaseViewModel {
     public gameUrl = observable<string | null>(null);
+    public boardUrl = observable<string | null>(null);
     public isAuthenticated = observable<boolean>(false);
     private api: LichessApiService | null = null;
     private auth: LichessAuthService;
@@ -18,7 +19,10 @@ export class LichessGameViewModel extends BaseViewModel {
                 <!-- ko if: isAuthenticated -->
                 <button data-bind="click: startGame">Start AI Game</button>
                 <button data-bind="click: logout">Logout</button>
-                <div data-bind="if: gameUrl">
+                <div data-bind="if: boardUrl">
+                    <iframe data-bind="attr: { src: boardUrl }" style="width: 600px; height: 397px; border:0;"></iframe>
+                </div>
+                <div data-bind="if: gameUrl" style="margin-top: 8px;">
                     <a data-bind="attr: { href: gameUrl }, text: gameUrl" target="_blank"></a>
                 </div>
                 <!-- /ko -->
@@ -46,6 +50,7 @@ export class LichessGameViewModel extends BaseViewModel {
         this.isAuthenticated(false);
         this.api = null;
         this.gameUrl(null);
+        this.boardUrl(null);
     }
 
     async startGame() {
@@ -62,6 +67,10 @@ export class LichessGameViewModel extends BaseViewModel {
             const response = await this.api.challengeAi();
             if (response.challenge && response.challenge.url) {
                 this.gameUrl(response.challenge.url);
+                const match = response.challenge.url.match(/lichess\.org\/(\w+)/);
+                if (match) {
+                    this.boardUrl(`https://lichess.org/embed/${match[1]}?theme=auto&bg=auto`);
+                }
             } else {
                 console.error("Unexpected response from Lichess", response);
             }

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,6 @@
     <title>App</title>
 </head>
 <body>
-
+<div id="app"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow playing an AI game directly inside the Knockout page
- show embedded Lichess board inside the game view
- add an `#app` container to the default HTML

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6864498d19d08326851b8546ad6964f8